### PR TITLE
added LauncherIntent - untested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ npm-debug.log
 system-notification.iml
 react-native-system-notification.iml
 .DS_Store
+.idea/
+*.iml
+local.properties

--- a/android/src/main/java/io/neson/react/notification/LauncherIntent.java
+++ b/android/src/main/java/io/neson/react/notification/LauncherIntent.java
@@ -1,0 +1,20 @@
+package io.neson.react.notification;
+
+import android.content.Context;
+import android.content.Intent;
+
+public class LauncherIntent {
+
+    public static Intent get(Context context) {
+        Intent intent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+        intent.setPackage(null);
+        intent.setFlags(0);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.setAction(Intent.ACTION_MAIN);
+        intent.addCategory(Intent.CATEGORY_LAUNCHER);
+        return intent;
+    }
+
+    private LauncherIntent() {
+    }
+}

--- a/android/src/main/java/io/neson/react/notification/NotificationEventReceiver.java
+++ b/android/src/main/java/io/neson/react/notification/NotificationEventReceiver.java
@@ -1,18 +1,16 @@
 package io.neson.react.notification;
 
-import android.content.ComponentName;
-import android.os.Build;
-import android.os.Bundle;
-import android.os.SystemClock;
 import android.app.ActivityManager;
 import android.app.ActivityManager.RunningAppProcessInfo;
-import android.content.Intent;
-import android.content.Context;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
 
 import java.util.List;
-
-import android.util.Log;
 
 /**
  * Handles user's interaction on notifications.
@@ -34,7 +32,7 @@ public class NotificationEventReceiver extends BroadcastReceiver {
         // passed in
         if (!applicationIsRunning(context)) {
             String packageName = context.getApplicationContext().getPackageName();
-            Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
+            Intent launchIntent = LauncherIntent.get(context);
 
             launchIntent.putExtra("initialSysNotificationId", extras.getInt(NOTIFICATION_ID));
             launchIntent.putExtra("initialSysNotificationAction", extras.getString(ACTION));


### PR DESCRIPTION
In response to android/src/main/java/io/neson/react/notification/NotificationEventReceiver.java,

This is one way I know you can launch the "launcher" intent similar to what the Android system does (resumes the app if it was running in the background / foreground, starts the app otherwise).

As I have negative free time, I did not test this fix at all. That's why I'm PR'ing it to you, if you want please see if everything still works.
